### PR TITLE
Password reset keys now expire after use.

### DIFF
--- a/dli_app/mod_admin/controllers.py
+++ b/dli_app/mod_admin/controllers.py
@@ -206,7 +206,7 @@ def delete_department(dept_id):
         return redirect(url_for('default.home'))
 
     department = Department.query.get(dept_id)
-    if department is not None:
+    if department:
         db.session.delete(department)
         db.session.commit()
 

--- a/dli_app/mod_auth/controllers.py
+++ b/dli_app/mod_auth/controllers.py
@@ -180,12 +180,11 @@ def setnewpass(reset_key):
     if not user:
         flash("That is not a valid reset_key. That key may have expired.", "alert-warning",)
         return redirect(url_for('default.home'))
+
     form = NewPassForm()
     if form.validate_on_submit():
-        password = form.password.data        
-        print "Deleting keys"
+        password = form.password.data
         for pw_reset in user.pw_reset:
-            print "Key"
             db.session.delete(pw_reset)
         user.set_password(password)
         db.session.commit()

--- a/dli_app/mod_auth/controllers.py
+++ b/dli_app/mod_auth/controllers.py
@@ -146,7 +146,7 @@ def resetpass():
     if form.validate_on_submit():
         email = form.email.data
         pw_reset = PasswordReset(
-            user= User.get_by_email(email),
+            user=User.get_by_email(email),
         )
         db.session.add(pw_reset)
         db.session.commit()
@@ -176,13 +176,17 @@ def setnewpass(reset_key):
     Arguments:
     reset_key - the unique key for resetting the password
     """
+    user = PasswordReset.get_by_key(reset_key)
+    if not user:
+        flash("That is not a valid reset_key. That key may have expired.", "alert-warning",)
+        return redirect(url_for('default.home'))
     form = NewPassForm()
     if form.validate_on_submit():
-        password = form.password.data
-        user = PasswordReset.get_by_key(reset_key)
-        if user is None:
-            flash("That is not a valid reset_key. Click the link in your email.", "alert-warning",)
-            return redirect(url_for('default.home'))
+        password = form.password.data        
+        print "Deleting keys"
+        for pw_reset in user.pw_reset:
+            print "Key"
+            db.session.delete(pw_reset)
         user.set_password(password)
         db.session.commit()
         flash("Password reset!", "alert-success")

--- a/dli_app/mod_auth/models.py
+++ b/dli_app/mod_auth/models.py
@@ -134,8 +134,8 @@ class User(db.Model):
     location_id = db.Column(db.Integer, db.ForeignKey("location.id"))
     dept_id = db.Column(db.Integer, db.ForeignKey("department.id"))
     pw_reset = db.relationship(
-	PasswordReset,
-	backref="user",
+	    PasswordReset,
+	    backref="user",
     )
     reports = db.relationship(
         Report,

--- a/dli_app/mod_auth/models.py
+++ b/dli_app/mod_auth/models.py
@@ -134,8 +134,8 @@ class User(db.Model):
     location_id = db.Column(db.Integer, db.ForeignKey("location.id"))
     dept_id = db.Column(db.Integer, db.ForeignKey("department.id"))
     pw_reset = db.relationship(
-	    PasswordReset,
-	    backref="user",
+        PasswordReset,
+        backref="user",
     )
     reports = db.relationship(
         Report,


### PR DESCRIPTION
If a expired key is used again, it now redirects to the homepage before rendering the form.
